### PR TITLE
Add EC2 backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # vignan
+
+This repository contains miscellaneous files and a simple script for backing up
+an EC2 instance.
+
+## EC2 Backup Script
+
+`ec2_backup.py` creates an Amazon Machine Image (AMI) from a specified EC2
+instance. The instance ID is read from the `EC2_INSTANCE_ID` environment
+variable. The AWS region defaults to `us-east-1` but can be overridden with the
+`AWS_REGION` environment variable.
+
+Run the script directly or schedule it with cron (or a similar tool) to create a
+backup once per day:
+
+```bash
+0 2 * * * /usr/bin/python3 /path/to/repo/ec2_backup.py >> /var/log/ec2_backup.log 2>&1
+```
+

--- a/ec2_backup.py
+++ b/ec2_backup.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Simple EC2 backup script.
+
+Creates an AMI of a specified EC2 instance. The instance ID is read from the
+EC2_INSTANCE_ID environment variable. The AWS region defaults to ``us-east-1``
+unless ``AWS_REGION`` is set.
+
+This script can be scheduled with cron or a similar tool to run daily.
+"""
+
+import os
+from datetime import datetime
+
+import boto3
+
+
+INSTANCE_ID = os.environ.get("EC2_INSTANCE_ID")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+
+def create_instance_backup(instance_id: str) -> None:
+    """Create an AMI from the provided EC2 instance."""
+    ec2 = boto3.client("ec2", region_name=REGION)
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")
+    name = f"backup-{instance_id}-{timestamp}"
+    response = ec2.create_image(InstanceId=instance_id, Name=name, NoReboot=True)
+    image_id = response.get("ImageId")
+    print(f"Created AMI {image_id} named {name}")
+
+
+def main() -> None:
+    instance_id = INSTANCE_ID
+    if not instance_id:
+        raise ValueError("EC2_INSTANCE_ID environment variable not set")
+    create_instance_backup(instance_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ec2_backup.py` for creating an AMI from a target EC2 instance
- document how to run the backup script and schedule it via cron in README

## Testing
- `python3 -m py_compile ec2_backup.py`

------
https://chatgpt.com/codex/tasks/task_e_68710d4da3bc8325acfc81b7a1735b42